### PR TITLE
Fix health check workflow - ensure PR creation in main repo

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -50,12 +50,12 @@ jobs:
       - name: Create Pull Request
         if: steps.check_changes.outputs.changes == 'true'
         run: |
-          # Ensure we're working with the main repository (not a fork)
-          REPO_FULL_NAME="${{ github.repository }}"
-          echo "Creating PR in repository: $REPO_FULL_NAME"
+          # Force PR creation in the main repository (aloi-tech/aloi-web-status)
+          MAIN_REPO="aloi-tech/aloi-web-status"
+          echo "Creating PR in main repository: $MAIN_REPO"
           
           PR_NUMBER=$(gh pr create \
-            --repo $REPO_FULL_NAME \
+            --repo $MAIN_REPO \
             --title "[Automated] Health Check Logs Update - $(date +%Y-%m-%d\ %H:%M)" \
             --body "## Health Check Logs Update
           
@@ -70,9 +70,9 @@ jobs:
             --head $BRANCH_NAME \
             --output json | jq -r '.number')
           
-          echo "Created PR #$PR_NUMBER in $REPO_FULL_NAME"
+          echo "Created PR #$PR_NUMBER in $MAIN_REPO"
           
           # Auto-merge the PR
-          gh pr merge $PR_NUMBER --repo $REPO_FULL_NAME --auto --merge --delete-branch
+          gh pr merge $PR_NUMBER --repo $MAIN_REPO --auto --merge --delete-branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -50,7 +50,12 @@ jobs:
       - name: Create Pull Request
         if: steps.check_changes.outputs.changes == 'true'
         run: |
+          # Ensure we're working with the main repository (not a fork)
+          REPO_FULL_NAME="${{ github.repository }}"
+          echo "Creating PR in repository: $REPO_FULL_NAME"
+          
           PR_NUMBER=$(gh pr create \
+            --repo $REPO_FULL_NAME \
             --title "[Automated] Health Check Logs Update - $(date +%Y-%m-%d\ %H:%M)" \
             --body "## Health Check Logs Update
           
@@ -65,9 +70,9 @@ jobs:
             --head $BRANCH_NAME \
             --output json | jq -r '.number')
           
-          echo "Created PR #$PR_NUMBER"
+          echo "Created PR #$PR_NUMBER in $REPO_FULL_NAME"
           
           # Auto-merge the PR
-          gh pr merge $PR_NUMBER --auto --merge --delete-branch
+          gh pr merge $PR_NUMBER --repo $REPO_FULL_NAME --auto --merge --delete-branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -11,10 +11,63 @@ jobs:
   health_check_job:
     permissions:
       contents: write 
+      pull-requests: write
     runs-on: ubuntu-latest
     name: Check all sites
     steps:
       - uses: actions/checkout@v4
-      - name: Run Shell Script
-        id: shell_script_run
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+      
+      - name: Configure Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+      
+      - name: Run Health Check Script
         run: bash ./scripts/health-check.sh
+      
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet; then
+            echo "changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "changes=true" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Create branch and commit
+        if: steps.check_changes.outputs.changes == 'true'
+        run: |
+          BRANCH_NAME="health-check-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b $BRANCH_NAME
+          git add public/status/
+          git commit -m "[Automated] Update Health Check Logs - $(date)"
+          git push origin $BRANCH_NAME
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+      
+      - name: Create Pull Request
+        if: steps.check_changes.outputs.changes == 'true'
+        run: |
+          PR_NUMBER=$(gh pr create \
+            --title "[Automated] Health Check Logs Update - $(date +%Y-%m-%d\ %H:%M)" \
+            --body "## Health Check Logs Update
+          
+          This PR contains automated health check logs generated at $(date).
+          
+          ### Changes:
+          - Updated health check logs for all monitored services
+          - Generated at: $(date)
+          
+          This is an automated update from the health check workflow." \
+            --base main \
+            --head $BRANCH_NAME \
+            --output json | jq -r '.number')
+          
+          echo "Created PR #$PR_NUMBER"
+          
+          # Auto-merge the PR
+          gh pr merge $PR_NUMBER --auto --merge --delete-branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Fix health check workflow

This PR resolves merge conflicts and ensures that automated health check PRs are created in the main repository (aloi-tech/aloi-web-status) instead of forks.

### Changes:
- Resolved merge conflict in health-check.yml
- Added pull-requests: write permission
- Used GITHUB_TOKEN instead of GH_PAT for consistency
- Hardcoded main repository (aloi-tech/aloi-web-status) to prevent PR creation in forks
- Maintained all PR creation and auto-merge functionality

### Technical Details:
- The workflow now explicitly specifies the main repository for PR creation
- This prevents automated health check PRs from being created in forks
- All health check logs will be properly merged into the main repository